### PR TITLE
Added channel vortex imprinting option

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -61,6 +61,12 @@ mutable struct ScalarVortex{T<:CoreShape} <: Vortex
     vort::PointVortex
 end
 
+mutable struct ChannelVortex{T<:CoreShape} <: Vortex
+    core::T
+    vort::PointVortex
+end
+
+
 mutable struct Dipole <: VortexGroup
     vp::PointVortex
     vn::PointVortex


### PR DESCRIPTION
Hi,

I am adding some of the code that I have in my fork which creates the correct vortex phase in a hard wall channel. The channel is assumed to be parallel to the x axis with its centre at the origin. I can try to pull it to the test branch but that seems to be very behind in commits so I am not sure if that is there for some other purpose. 