### PR TITLE
Phase 3: add typed experimental 3D API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,51 @@ The typed `Detection3DResult` returned by `detect_vortices_3d` is the preferred 
 
 The package test suite exercises the vendored backend against the reference fixture at `test/3d/box_vorts.jld2`.
 
+## Deeper 3D Testing
+
+For heavier manual validation, this repo includes a local workflow for generating
+and analyzing 64^3 reference data with the experimental 3D detector.
+
+1. Install the optional simulation dependency:
+
+```bash
+julia --project=. -e 'using Pkg; Pkg.add("FourierGPE")'
+```
+
+2. Generate reference data:
+
+```bash
+julia --project=. examples/generate_3d_validation_data.jl
+```
+
+This writes:
+
+- `examples/3d_validation_data/sim_64.jld2`
+- `examples/3d_validation_data/sol_64.jld2`
+
+3. Run the deeper validation script:
+
+```bash
+julia --project=. examples/timcop_deep_test.jl \
+  examples/3d_validation_data/sim_64.jld2 \
+  examples/3d_validation_data/sol_64.jld2
+```
+
+Optional arguments:
+
+- third argument: simulation time index, default `20`
+- fourth argument: interpolation factor `n_itp`, default `4`
+
+The script:
+
+- loads the generated 64^3 simulation data
+- runs `detect_vortices_3d(psi, x, y, z; n_itp=...)`
+- computes connected vortex structures with `Detection3D.connect_vortex_ends`
+- prints a structural summary
+- saves a JLD2 bundle of the result next to the supplied solution file
+
+This path is intended for exploratory validation and stress testing that is too heavy or dataset-specific for the package test suite.
+
 # Installation
 ```julia
 ]add VortexDistributions

--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@ The integrated 3D detection backend from `timcop/VortexDetection.jl` now lives u
 VortexDistributions.Detection3D.TimCop
 ```
 
-The experimental root entry point `VortexDistributions.full_algorithm` now routes to that vendored backend. The older code path is still preserved under `VortexDistributions.Detection3D.Legacy` for comparison only.
+The experimental root entry points are:
+
+```julia
+result = detect_vortices_3d(psi, x, y, z)
+g, lines, loops, rings, coords, periodic_edges = full_algorithm(psi, x, y, z) # compatibility wrapper
+```
+
+The typed `Detection3DResult` returned by `detect_vortices_3d` is the preferred phase 3 API. The older code path is still preserved under `VortexDistributions.Detection3D.Legacy` for comparison only.
 
 The package test suite exercises the vendored backend against the reference fixture at `test/3d/box_vorts.jld2`.
 

--- a/examples/generate_3d_validation_data.jl
+++ b/examples/generate_3d_validation_data.jl
@@ -1,0 +1,68 @@
+"""
+Generate 64^3 validation data for the experimental 3D detector using FourierGPE.
+
+Usage:
+
+    julia --project=. examples/generate_3d_validation_data.jl [output_dir] [tf] [Nt]
+
+Defaults:
+- output_dir = examples/3d_validation_data
+- tf = 80.0
+- Nt = 100
+
+This script is intentionally kept out of the package test suite because it can
+take a few minutes and requires the optional `FourierGPE` dependency.
+"""
+
+using JLD2
+using VortexDistributions
+
+try
+    @eval using FourierGPE
+catch err
+    error("This script requires the optional FourierGPE dependency.\n" *
+          "Install it in your active environment with:\n" *
+          "  julia --project=. -e 'using Pkg; Pkg.add(\"FourierGPE\")'\n\n" *
+          "Original load error: $(sprint(showerror, err))")
+end
+
+function main(args)
+    output_dir = length(args) >= 1 ? args[1] : joinpath(@__DIR__, "3d_validation_data")
+    tf = length(args) >= 2 ? parse(Float64, args[2]) : 80.0
+    Nt = length(args) >= 3 ? parse(Int, args[3]) : 100
+
+    mkpath(output_dir)
+
+    L = (16.0, 16.0, 16.0)
+    N = (64, 64, 64)
+    sim = Sim(L, N)
+    @unpack_Sim sim
+
+    μ = 25.0
+    γ = 0.05
+    t = LinRange(0.0, tf, Nt)
+
+    x, y, z = X
+    ψi = randn(N) + im * randn(N)
+    ϕi = kspace(ψi, sim)
+
+    @pack_Sim! sim = μ, γ, t, ψi, ϕi
+
+    println("Running FourierGPE simulation for 3D validation...")
+    sol = runsim(sim)
+
+    for i in eachindex(sol)
+        sol[i] = xspace(sol[i], sim)
+    end
+
+    sim_path = joinpath(output_dir, "sim_64.jld2")
+    sol_path = joinpath(output_dir, "sol_64.jld2")
+    @save sim_path sim
+    @save sol_path sol
+
+    println("Wrote:")
+    println("  $sim_path")
+    println("  $sol_path")
+end
+
+main(ARGS)

--- a/examples/timcop_deep_test.jl
+++ b/examples/timcop_deep_test.jl
@@ -1,0 +1,59 @@
+using Graphs
+using JLD2
+using VortexDistributions
+
+"""
+Run a deeper 3D validation pass against simulation output generated from the
+local `examples/generate_3d_validation_data.jl` workflow.
+
+Usage:
+
+    julia --project=. examples/timcop_deep_test.jl path/to/sim_64.jld2 path/to/sol_64.jld2 [t] [n_itp]
+
+Arguments:
+- `sim_64.jld2`: expected to contain `sim.X`
+- `sol_64.jld2`: expected to contain `sol`, a callable solution object
+- `t`: optional simulation time index, default `20`
+- `n_itp`: optional interpolation factor, default `4`
+"""
+
+function main(args)
+    if length(args) < 2
+        error("Usage: julia --project=. examples/timcop_deep_test.jl sim_64.jld2 sol_64.jld2 [t] [n_itp]")
+    end
+
+    sim_path = args[1]
+    sol_path = args[2]
+    t = length(args) >= 3 ? parse(Int, args[3]) : 20
+    n_itp = length(args) >= 4 ? parse(Int, args[4]) : 4
+
+    @load sim_path sim
+    @load sol_path sol
+
+    psi = sol(t)
+    X = sim.X
+    x, y, z = X
+    x = round.(x, digits = 3)
+    y = round.(y, digits = 3)
+    z = round.(z, digits = 3)
+
+    result = detect_vortices_3d(psi, x, y, z; n_itp = n_itp)
+    connected = VortexDistributions.Detection3D.connect_vortex_ends(result, X)
+
+    println("3D detection summary")
+    println("  time index: $t")
+    println("  interpolation factor: $n_itp")
+    println("  graph vertices: $(Graphs.nv(result.graph))")
+    println("  graph edges: $(Graphs.ne(result.graph))")
+    println("  filament lines: $(length(result.vortex_lines))")
+    println("  filament loops: $(length(result.vortex_loops))")
+    println("  filament rings: $(length(result.vortex_rings))")
+    println("  connected vortex structures: $(length(connected))")
+    println("  periodic edges: $(length(result.periodic_edges))")
+
+    output_path = joinpath(dirname(sol_path), "vortex_detection_result_t$(t)_n$(n_itp).jld2")
+    @save output_path result connected
+    println("  wrote result bundle: $output_path")
+end
+
+main(ARGS)

--- a/src/Detection3D.jl
+++ b/src/Detection3D.jl
@@ -5,6 +5,20 @@ abstract type AbstractDetectionBackend3D end
 struct LegacyPlaneBackend3D <: AbstractDetectionBackend3D end
 struct TimCopBackend3D <: AbstractDetectionBackend3D end
 
+struct Detection3DResult{G, C, E}
+    graph::G
+    vortex_lines::Vector
+    vortex_loops::Vector
+    vortex_rings::Vector
+    coords::C
+    periodic_edges::E
+end
+
+function Detection3DResult(graph, vortex_lines, vortex_loops, vortex_rings, coords;
+                           periodic_edges = Tuple{Int, Int}[])
+    return Detection3DResult(graph, vortex_lines, vortex_loops, vortex_rings, coords, periodic_edges)
+end
+
 module TimCop
 
 using Base.Threads
@@ -13,6 +27,7 @@ using Graphs
 using Interpolations
 
 using ...Analysis2D: phase_jumps
+using ..Detection3D: Detection3DResult
 
 include("Detection3D/timcop.jl")
 
@@ -30,12 +45,34 @@ include("Detection3D/legacy.jl")
 
 end
 
-full_algorithm(args...; kwargs...) = TimCop.full_algorithm(args...; kwargs...)
-full_algorithm(::TimCopBackend3D, args...; kwargs...) = TimCop.full_algorithm(args...; kwargs...)
-full_algorithm(::LegacyPlaneBackend3D, args...; kwargs...) = Legacy.full_algorithm(args...; kwargs...)
+detect_vortices_3d(args...; backend::AbstractDetectionBackend3D = TimCopBackend3D(), kwargs...) =
+    detect_vortices_3d(backend, args...; kwargs...)
+detect_vortices_3d(::TimCopBackend3D, args...; kwargs...) = TimCop.detect_vortices_3d(args...; kwargs...)
+detect_vortices_3d(::LegacyPlaneBackend3D, args...; kwargs...) = Detection3DResult(Legacy.full_algorithm(args...; kwargs...)...)
+
+function full_algorithm(args...; backend::AbstractDetectionBackend3D = TimCopBackend3D(), kwargs...)
+    result = detect_vortices_3d(args...; backend = backend, kwargs...)
+    return result.graph,
+        result.vortex_lines,
+        result.vortex_loops,
+        result.vortex_rings,
+        result.coords,
+        result.periodic_edges
+end
+
+full_algorithm(::TimCopBackend3D, args...; kwargs...) = full_algorithm(args...; backend = TimCopBackend3D(), kwargs...)
+full_algorithm(::LegacyPlaneBackend3D, args...; kwargs...) = full_algorithm(args...; backend = LegacyPlaneBackend3D(), kwargs...)
 
 connect_vortex_ends(args...; kwargs...) = TimCop.connect_vortex_ends(args...; kwargs...)
+connect_vortex_ends(result::Detection3DResult, X) =
+    connect_vortex_ends(result.coords, result.vortex_lines, result.vortex_loops, result.vortex_rings, X)
 
-export AbstractDetectionBackend3D, LegacyPlaneBackend3D, TimCopBackend3D, connect_vortex_ends, full_algorithm
+export AbstractDetectionBackend3D,
+    Detection3DResult,
+    LegacyPlaneBackend3D,
+    TimCopBackend3D,
+    connect_vortex_ends,
+    detect_vortices_3d,
+    full_algorithm
 
 end

--- a/src/Detection3D/timcop.jl
+++ b/src/Detection3D/timcop.jl
@@ -390,3 +390,7 @@ function full_algorithm(psi, x, y, z; n_itp = 1, repeat_end_of_ring = true)
 
     return g, vort_lines, vort_loops, vort_rings, vorts_coords, edge_list_periodic
 end
+
+function detect_vortices_3d(psi, x, y, z; n_itp = 1, repeat_end_of_ring = true)
+    return Detection3DResult(full_algorithm(psi, x, y, z; n_itp = n_itp, repeat_end_of_ring = repeat_end_of_ring)...)
+end

--- a/src/VortexDistributions.jl
+++ b/src/VortexDistributions.jl
@@ -36,7 +36,7 @@ using .Creation2D: gpecore_exact,
     dipole_phase,
     vortex!
 using .Detection2D: findvortices, findvortices_grid, findvortices_jumps, found_near, remove_vortices_edge
-using .Detection3D: full_algorithm
+using .Detection3D: detect_vortices_3d, full_algorithm
 
 const Detection3DLegacy = Detection3D.Legacy
 
@@ -52,6 +52,7 @@ export thetad
 export charge, xpos, ypos, pos
 export VortexGroup, Dipole, Cluster
 export Vortex, CoreShape, Ansatz, Exact
+export detect_vortices_3d
 
 using .Core: rand_pointvortex
 

--- a/test/3d/timcop_backend_test.jl
+++ b/test/3d/timcop_backend_test.jl
@@ -8,8 +8,13 @@ using VortexDistributions
 psi = psi_tubes1
 x, y, z = X
 
-g, vort_lines, vort_loops, vort_rings, vorts_coords, edge_list_periodic =
-    VortexDistributions.Detection3D.TimCop.full_algorithm(psi, x, y, z)
+result = VortexDistributions.detect_vortices_3d(psi, x, y, z)
+g = result.graph
+vort_lines = result.vortex_lines
+vort_loops = result.vortex_loops
+vort_rings = result.vortex_rings
+vorts_coords = result.coords
+edge_list_periodic = result.periodic_edges
 
 @test Graphs.nv(g) == length(vorts_coords)
 @test Graphs.ne(g) > 0
@@ -17,13 +22,7 @@ g, vort_lines, vort_loops, vort_rings, vorts_coords, edge_list_periodic =
 @test (length(vort_lines), length(vort_loops), length(vort_rings)) == (16, 0, 1)
 @test !isempty(edge_list_periodic)
 
-connected_vorts = VortexDistributions.Detection3D.TimCop.connect_vortex_ends(
-    vorts_coords,
-    vort_lines,
-    vort_loops,
-    vort_rings,
-    X,
-)
+connected_vorts = VortexDistributions.Detection3D.connect_vortex_ends(result, X)
 
 @test length(connected_vorts) == 3
 

--- a/test/api_regression_test.jl
+++ b/test/api_regression_test.jl
@@ -7,6 +7,7 @@ using VortexDistributions
 @test isdefined(VortexDistributions, :Analysis2D)
 @test isdefined(VortexDistributions, :Detection3D)
 @test isdefined(VortexDistributions, :Detection3DLegacy)
+@test isdefined(VortexDistributions, :detect_vortices_3d)
 
 for name in (
     :Field,


### PR DESCRIPTION
## Summary
- add a typed Detection3DResult container and expose detect_vortices_3d as the preferred experimental 3D API
- keep full_algorithm as a compatibility wrapper over the typed result path
- extend 3D regression coverage around the typed TimCop backend API
- add a self-contained local 3D validation workflow in examples, including data generation and deeper manual testing scripts

## Testing
- julia --project=. test/runtests.jl