### PR TITLE
Codex/merge rca research

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -731,7 +731,7 @@ version = "1.11.0"
 deps = ["FFTW", "FLoops", "Graphs", "Interpolations", "JLD2", "LinearAlgebra", "Parameters", "SimpleWeightedGraphs", "SparseArrays", "SpecialFunctions", "UnPack"]
 path = "."
 uuid = "b688e990-d167-11e8-1f13-43a2532b2fa8"
-version = "0.3.9"
+version = "0.3.10"
 
 [[deps.WoodburyMatrices]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "VortexDistributions"
 uuid = "b688e990-d167-11e8-1f13-43a2532b2fa8"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Ashton Bradley <ashton.bradley@gmail.com>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ and density at successive zoom levels with vortex location and detected location
    4.037 ms (585 allocations: 3.84 MiB)
  ```
 
+## Recursive Cluster Algorithm Example
+
+The recursive cluster algorithm (RCA) is available under:
+
+```julia
+VortexDistributions.RecursiveClusterAlgorithm
+```
+
+A simple usage example:
+
+```julia
+using VortexDistributions
+
+const RCA = VortexDistributions.RecursiveClusterAlgorithm
+
+include("examples/rca_random_example.jl")
+```
+
+A runnable usage example lives in `examples/rca_random_example.jl`. It:
+
+- generates a random set of 10 positive and 10 negative vortices
+- runs `RCA.recursive_cluster_algorithm(...)`
+- saves a `Plots.jl` classification figure to `examples/rca_random_example.png`
+- overlays stream-function contours computed from the point-vortex field on a `100 x 100` grid
+- draws cluster minimal spanning trees and dipole links on top of the vortex markers
+
 ## Experimental 3D API
 
 The integrated 3D detection backend from `timcop/VortexDetection.jl` now lives under:

--- a/README.md
+++ b/README.md
@@ -110,13 +110,17 @@ const RCA = VortexDistributions.RecursiveClusterAlgorithm
 include("examples/rca_random_example.jl")
 ```
 
-A runnable usage example lives in `examples/rca_random_example.jl`. It:
+A runnable usage example lives in `examples/rca_random_example.jl`.
 
-- generates a random set of 10 positive and 10 negative vortices
-- runs `RCA.recursive_cluster_algorithm(...)`
-- saves a `Plots.jl` classification figure to `examples/rca_random_example.png`
-- overlays stream-function contours computed from the point-vortex field on a `100 x 100` grid
-- draws cluster minimal spanning trees and dipole links on top of the vortex markers
+It generates a random set of 10 positive and 10 negative vortices, runs
+`RCA.recursive_cluster_algorithm(...)`, and saves a `Plots.jl` classification
+figure with:
+
+- stream-function contours computed from the point-vortex field on a `100 x 100` grid
+- cluster minimal spanning trees and dipole links
+- color-coded positive and negative vortices
+
+![](/examples/rca_random_example.png)
 
 ## Experimental 3D API
 

--- a/examples/rca_plot_helpers.jl
+++ b/examples/rca_plot_helpers.jl
@@ -1,0 +1,195 @@
+const RCA = VortexDistributions.RecursiveClusterAlgorithm
+
+function classify_vortices(vortices, result)
+    labels = fill("free vortex", length(vortices))
+    colors = [vortex.qv > 0 ? "red" : "dodgerblue" for vortex in vortices]
+
+    for dipole in result.dipoles
+        for member in (dipole.vp, dipole.vn)
+            idx = findfirst(isequal(member), vortices)
+            if !isnothing(idx)
+                labels[idx] = "dipole"
+            end
+        end
+    end
+
+    for (cluster_index, cluster) in pairs(result.positive_clusters)
+        for member in cluster.vortices
+            idx = findfirst(isequal(member), vortices)
+            if !isnothing(idx)
+                labels[idx] = "positive cluster $cluster_index"
+            end
+        end
+    end
+
+    for (cluster_index, cluster) in pairs(result.negative_clusters)
+        for member in cluster.vortices
+            idx = findfirst(isequal(member), vortices)
+            if !isnothing(idx)
+                labels[idx] = "negative cluster $cluster_index"
+            end
+        end
+    end
+
+    return labels, colors
+end
+
+function point_vortex_streamfunction(vortices, xgrid, ygrid; core = 0.03)
+    ψ = zeros(length(ygrid), length(xgrid))
+    core2 = core^2
+
+    for (j, y) in pairs(ygrid)
+        for (i, x) in pairs(xgrid)
+            value = 0.0
+            for vortex in vortices
+                dx = x - vortex.xv
+                dy = y - vortex.yv
+                r2 = dx^2 + dy^2 + core2
+                value -= vortex.qv * log(r2) / (4π)
+            end
+            ψ[j, i] = value
+        end
+    end
+
+    return ψ
+end
+
+function plot_rca_connections!(plt, result)
+    dipole_color = "mediumseagreen"
+    positive_color = "red"
+    negative_color = "dodgerblue"
+
+    for dipole in result.dipoles
+        plot!(
+            plt,
+            [dipole.vp.xv, dipole.vn.xv],
+            [dipole.vp.yv, dipole.vn.yv],
+            color = dipole_color,
+            linewidth = 2.8,
+            alpha = 0.9,
+            label = "",
+        )
+    end
+
+    for cluster in result.positive_clusters
+        for edge in cluster.tree
+            src = cluster.vortices[edge.src]
+            dst = cluster.vortices[edge.dst]
+            plot!(
+                plt,
+                [src.xv, dst.xv],
+                [src.yv, dst.yv],
+                color = positive_color,
+                linewidth = 2.2,
+                alpha = 0.9,
+                label = "",
+            )
+        end
+    end
+
+    for cluster in result.negative_clusters
+        for edge in cluster.tree
+            src = cluster.vortices[edge.src]
+            dst = cluster.vortices[edge.dst]
+            plot!(
+                plt,
+                [src.xv, dst.xv],
+                [src.yv, dst.yv],
+                color = negative_color,
+                linewidth = 2.2,
+                alpha = 0.9,
+                label = "",
+            )
+        end
+    end
+end
+
+function plot_rca_example(vortices, result, labels, colors; Lx = 2.0, Ly = 2.0, title = "Recursive Cluster Algorithm Classification")
+    gr()
+    y_line_offset = 0.015 * Ly
+
+    plt = plot(
+        xlabel = "x",
+        ylabel = "y",
+        title = title,
+        xlims = (-Lx / 2, Lx / 2),
+        ylims = (-Ly / 2, Ly / 2),
+        aspect_ratio = :equal,
+        legend = :outertop,
+        framestyle = :box,
+        grid = true,
+        background_color = RGB(0.99, 0.99, 0.97),
+        foreground_color_grid = RGBA(0.7, 0.7, 0.7, 0.35),
+        size = (900, 600),
+    )
+
+    xgrid = range(-Lx / 2, Lx / 2; length = 100)
+    ygrid = range(-Ly / 2, Ly / 2; length = 100)
+    ψ = point_vortex_streamfunction(vortices, xgrid, ygrid)
+
+    contour!(
+        plt,
+        collect(xgrid),
+        collect(ygrid),
+        ψ,
+        levels = 40,
+        c = :thermal,
+        linewidth = 1.8,
+        alpha = 0.65,
+        colorbar = false,
+        label = "",
+    )
+
+    plot_rca_connections!(plt, result)
+
+    for (idx, vortex) in pairs(vortices)
+        annotate!(
+            plt,
+            vortex.xv,
+            vortex.yv + (vortex.qv > 0 ? y_line_offset / 2 : 7y_line_offset / 10),
+            text(vortex.qv > 0 ? "+" : "-", vortex.qv > 0 ? 15 : 30, colors[idx], :center, "Computer Modern"),
+        )
+    end
+
+    legend_entries = [
+        ("positive cluster", "red"),
+        ("negative cluster", "dodgerblue"),
+        ("vortex dipole", "mediumseagreen"),
+    ]
+
+    for (label, color) in legend_entries
+        if label == "positive cluster" && isempty(result.positive_clusters)
+            continue
+        elseif label == "negative cluster" && isempty(result.negative_clusters)
+            continue
+        elseif label == "vortex dipole" && isempty(result.dipoles)
+            continue
+        end
+        plot!(
+            plt,
+            [NaN, NaN],
+            [NaN, NaN],
+            color = color,
+            linewidth = 4.5,
+            label = label,
+        )
+    end
+
+    return plt
+end
+
+function print_rca_summary(result, plot_path)
+    println("Dipoles: ", length(result.dipoles))
+    println("Positive clusters: ", length(result.positive_clusters))
+    println("Negative clusters: ", length(result.negative_clusters))
+    println("Free vortices: ", length(result.free_vortices))
+    println("Saved plot: ", plot_path)
+
+    for (i, cluster) in pairs(result.positive_clusters)
+        println("Positive cluster $i has $(length(cluster.vortices)) vortices")
+    end
+
+    for (i, cluster) in pairs(result.negative_clusters)
+        println("Negative cluster $i has $(length(cluster.vortices)) vortices")
+    end
+end

--- a/examples/rca_random_example.jl
+++ b/examples/rca_random_example.jl
@@ -1,0 +1,42 @@
+using Random
+using VortexDistributions
+using Plots
+
+include("rca_plot_helpers.jl")
+
+Random.seed!(31)
+
+Lx = 2.0
+Ly = 2.0
+Nplus = 10
+Nminus = 10
+
+function random_vortices(n, charge; Lx = 2.0, Ly = 2.0, margin = 0.12)
+    xs = rand(n) .* (Lx - 2margin) .- (Lx / 2 - margin)
+    ys = rand(n) .* (Ly - 2margin) .- (Ly / 2 - margin)
+    return PointVortex.(xs, ys, fill(charge, n))
+end
+
+vortices = vcat(
+    random_vortices(Nplus, 1; Lx = Lx, Ly = Ly),
+    random_vortices(Nminus, -1; Lx = Lx, Ly = Ly),
+)
+
+result = RCA.recursive_cluster_algorithm(vortices, Lx, Ly)
+labels, colors = classify_vortices(vortices, result)
+
+plot_path = joinpath(@__DIR__, "rca_random_example.png")
+plt = plot_rca_example(
+    vortices,
+    result,
+    labels,
+    colors;
+    Lx = Lx,
+    Ly = Ly,
+    title = "RCA Classification for Random 10+/10- Vortices with Stream Function",
+)
+savefig(plt, plot_path)
+
+println("Random seed: 31")
+println("Total vortices: ", length(vortices), " (", Nplus, " positive, ", Nminus, " negative)")
+print_rca_summary(result, plot_path)


### PR DESCRIPTION
### Release Notes for v0.3.10

This release adds a documented usage example for the Recursive Cluster Algorithm (RCA), including a visual classification plot for randomly generated vortex configurations.

#### Highlights

Added a new RCA usage example at examples/rca_random_example.jl
Added shared RCA plotting utilities at examples/rca_plot_helpers.jl
Updated the README RCA section to point directly to the usage example and show the generated figure
New RCA Example

#### The new example:

generates a random set of 10 positive and 10 negative point vortices
runs VortexDistributions.RecursiveClusterAlgorithm.recursive_cluster_algorithm
produces a classification plot using Plots.jl
overlays point-vortex stream-function contours on a 100 x 100 grid
draws:
cluster minimal spanning trees
vortex dipole links
signed vortex markers (+ / -)
Plot Styling

The RCA example figure now uses:

red for all positive vortices and positive-cluster links
dodgerblue for all negative vortices and negative-cluster links
mediumseagreen for vortex dipole links
boxed axes with the legend above the plot
simplified legend labels:
positive cluster
negative cluster
vortex dipole

#### Versioning

Bumped package version from 0.3.9 to 0.3.10
Synced Manifest.toml to the new package version 

Validated by running:

```
julia --project=. examples/rca_random_example.jl
```

The example writes the figure to examples/rca_random_example.png.