### PR TITLE
Add same-sign Ripley clustering analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,32 @@ For more detail see the usage example script
 
 `/examples/rca_random_example.jl`
 
+## Same-sign Ripley clustering
+
+The 2D analysis tools include same-sign Ripley K statistics in a physical disk
+window. The CSR-subtracted curve
+
+```julia
+H_excess(r) = H_observed(r) - mean(H_CSR(r))
+```
+
+quantifies excess clustering relative to homogeneous random same-sign vortices
+in the same disk. The example below compares homogeneous synthetic vortices
+with a two-cluster distribution and writes the plotted diagnostic:
+
+```bash
+julia --project=. examples/ripley_disk_synthetic.jl
+```
+
+![](/examples/ripley_disk_synthetic.svg)
+
+For Monte Carlo calibration of the Ripley peak against the known Gaussian
+cluster width, run:
+
+```bash
+julia --project=. examples/ripley_peak_calibration.jl
+```
+
 ## Experimental 3D API
 
 ![](/examples/quench_64_subfigures_taller.png)

--- a/examples/ripley_disk_synthetic.jl
+++ b/examples/ripley_disk_synthetic.jl
@@ -1,0 +1,200 @@
+using Printf
+using Random
+using VortexDistributions
+
+function random_disk_point(rng::AbstractRNG, radius::Real)
+    ρ = radius * sqrt(rand(rng))
+    θ = 2π * rand(rng)
+    return ρ * cos(θ), ρ * sin(θ)
+end
+
+function random_disk_vortices(rng::AbstractRNG, n::Integer, q::Integer, radius::Real)
+    return [PointVortex(random_disk_point(rng, radius)..., q) for _ = 1:n]
+end
+
+function clustered_disk_vortices(
+    rng::AbstractRNG,
+    n::Integer,
+    q::Integer,
+    radius::Real;
+    centers = [(-0.35radius, 0.15radius), (0.30radius, -0.20radius)],
+    cluster_width = 0.07radius,
+)
+    vortices = PointVortex[]
+    while length(vortices) < n
+        x0, y0 = rand(rng, centers)
+        x = x0 + cluster_width * randn(rng)
+        y = y0 + cluster_width * randn(rng)
+        hypot(x, y) <= radius && push!(vortices, PointVortex(x, y, q))
+    end
+    return vortices
+end
+
+function print_summary(name, summary)
+    @printf(
+        "%-12s max(H_excess) = %8.4f at r = %6.3f, positive integral = %8.4f\n",
+        name,
+        summary.maximum,
+        summary.radius,
+        summary.integral,
+    )
+end
+
+function points_path(x, y, xmin, xmax, ymin, ymax, width, height, margin)
+    xs = @. margin + (x - xmin) / (xmax - xmin) * (width - 2margin)
+    ys = @. height - margin - (y - ymin) / (ymax - ymin) * (height - 2margin)
+    return join(
+        ("$(round(xs[i], digits = 2)),$(round(ys[i], digits = 2))" for i in eachindex(xs)),
+        " ",
+    )
+end
+
+function xcoord(x, xmin, xmax, width, margin)
+    return margin + (x - xmin) / (xmax - xmin) * (width - 2margin)
+end
+
+function ycoord(y, ymin, ymax, height, margin)
+    return height - margin - (y - ymin) / (ymax - ymin) * (height - 2margin)
+end
+
+function write_svg(path, r, homogeneous, clustered; calibrated_peak_scale)
+    width = 780
+    height = 460
+    margin = 56
+    ymin = min(minimum(homogeneous), minimum(clustered), -0.05)
+    ymax = max(maximum(homogeneous), maximum(clustered), 0.05)
+    pad = 0.08 * (ymax - ymin)
+    ymin -= pad
+    ymax += pad
+    xmin, xmax = extrema(r)
+    zero_y = ycoord(0, ymin, ymax, height, margin)
+    hom_path = points_path(r, homogeneous, xmin, xmax, ymin, ymax, width, height, margin)
+    clu_path = points_path(r, clustered, xmin, xmax, ymin, ymax, width, height, margin)
+    scale_x = xcoord(calibrated_peak_scale, xmin, xmax, width, margin)
+    xticks = collect(0.1:0.1:0.6)
+    yticks = collect(0.0:0.1:0.5)
+
+    open(path, "w") do io
+        println(
+            io,
+            """<svg xmlns="http://www.w3.org/2000/svg" width="$width" height="$height" viewBox="0 0 $width $height">""",
+        )
+        println(io, """<rect width="100%" height="100%" fill="white"/>""")
+        println(
+            io,
+            """<text x="24" y="34" font-family="Helvetica,Arial,sans-serif" font-size="20" fill="#222">Same-sign Ripley excess in a disk</text>""",
+        )
+        println(
+            io,
+            """<line x1="$margin" y1="$(height - margin)" x2="$(width - margin)" y2="$(height - margin)" stroke="#333"/>""",
+        )
+        println(
+            io,
+            """<line x1="$margin" y1="$margin" x2="$margin" y2="$(height - margin)" stroke="#333"/>""",
+        )
+        println(
+            io,
+            """<line x1="$margin" y1="$zero_y" x2="$(width - margin)" y2="$zero_y" stroke="#999" stroke-dasharray="5 5"/>""",
+        )
+        for tick in xticks
+            x = xcoord(tick, xmin, xmax, width, margin)
+            println(
+                io,
+                """<line x1="$x" y1="$(height - margin)" x2="$x" y2="$(height - margin + 6)" stroke="#333"/>""",
+            )
+            println(
+                io,
+                """<text x="$x" y="$(height - margin + 24)" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">$(round(tick, digits = 1))</text>""",
+            )
+        end
+        for tick in yticks
+            y = ycoord(tick, ymin, ymax, height, margin)
+            println(
+                io,
+                """<line x1="$(margin - 6)" y1="$y" x2="$margin" y2="$y" stroke="#333"/>""",
+            )
+            println(
+                io,
+                """<text x="$(margin - 10)" y="$(y + 4)" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">$(round(tick, digits = 1))</text>""",
+            )
+        end
+        println(
+            io,
+            """<line x1="$scale_x" y1="$margin" x2="$scale_x" y2="$(height - margin)" stroke="#111" stroke-width="2.5" stroke-dasharray="6 4"/>""",
+        )
+        println(io, """<circle cx="$scale_x" cy="$(height - margin)" r="4" fill="#111"/>""")
+        println(
+            io,
+            """<polyline fill="none" stroke="#4b6cb7" stroke-width="3" points="$hom_path"/>""",
+        )
+        println(
+            io,
+            """<polyline fill="none" stroke="#c43c39" stroke-width="3" points="$clu_path"/>""",
+        )
+        println(
+            io,
+            """<text x="$(width - 240)" y="72" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#4b6cb7">homogeneous - CSR</text>""",
+        )
+        println(
+            io,
+            """<text x="$(width - 240)" y="96" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#c43c39">clustered - CSR</text>""",
+        )
+        println(
+            io,
+            """<text x="$scale_x" y="$(margin - 14)" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="14" font-weight="bold" fill="#111">reference r = $(round(calibrated_peak_scale, digits = 3))</text>""",
+        )
+        println(
+            io,
+            """<text x="$(width / 2 - 40)" y="$(height - 16)" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#222">r</text>""",
+        )
+        println(
+            io,
+            """<text x="14" y="$(height / 2)" transform="rotate(-90 14,$(height / 2))" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#222">H_excess(r)</text>""",
+        )
+        println(io, "</svg>")
+    end
+end
+
+rng = MersenneTwister(42)
+window = DiskWindow(1.0)
+r = collect(range(0.02, 0.65; length = 64))
+cluster_width = 0.07window.radius
+
+homogeneous = random_disk_vortices(rng, 40, 1, window.radius)
+clustered = clustered_disk_vortices(rng, 40, 1, window.radius; cluster_width)
+
+homogeneous_summary = ripley_excess(
+    homogeneous,
+    r,
+    window;
+    charge = 1,
+    samples = 300,
+    rng = MersenneTwister(1),
+)
+clustered_summary =
+    ripley_excess(clustered, r, window; charge = 1, samples = 300, rng = MersenneTwister(1))
+
+println("Same-sign Ripley clustering in a disk window")
+print_summary("homogeneous", homogeneous_summary)
+print_summary("clustered", clustered_summary)
+
+plot_path = joinpath(@__DIR__, "ripley_disk_synthetic.svg")
+write_svg(
+    plot_path,
+    r,
+    homogeneous_summary.H,
+    clustered_summary.H;
+    calibrated_peak_scale = 2.86cluster_width,
+)
+println("Wrote figure: ", plot_path)
+
+println("\nSample H_excess(r) = H_observed(r) - mean(H_CSR(r)) values")
+println("r      homogeneous   clustered")
+for index = 1:8:length(r)
+    @printf(
+        "%5.3f  %11.4f  %10.4f\n",
+        r[index],
+        homogeneous_summary.H[index],
+        clustered_summary.H[index],
+    )
+end

--- a/examples/ripley_disk_synthetic.svg
+++ b/examples/ripley_disk_synthetic.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="780" height="460" viewBox="0 0 780 460">
+<rect width="100%" height="100%" fill="white"/>
+<text x="24" y="34" font-family="Helvetica,Arial,sans-serif" font-size="20" fill="#222">Same-sign Ripley excess in a disk</text>
+<line x1="56" y1="404" x2="724" y2="404" stroke="#333"/>
+<line x1="56" y1="56" x2="56" y2="404" stroke="#333"/>
+<line x1="56" y1="350.08834578681115" x2="724" y2="350.08834578681115" stroke="#999" stroke-dasharray="5 5"/>
+<line x1="140.8253968253968" y1="404" x2="140.8253968253968" y2="410" stroke="#333"/>
+<text x="140.8253968253968" y="428" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.1</text>
+<line x1="246.8571428571429" y1="404" x2="246.8571428571429" y2="410" stroke="#333"/>
+<text x="246.8571428571429" y="428" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.2</text>
+<line x1="352.88888888888886" y1="404" x2="352.88888888888886" y2="410" stroke="#333"/>
+<text x="352.88888888888886" y="428" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.3</text>
+<line x1="458.9206349206349" y1="404" x2="458.9206349206349" y2="410" stroke="#333"/>
+<text x="458.9206349206349" y="428" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.4</text>
+<line x1="564.952380952381" y1="404" x2="564.952380952381" y2="410" stroke="#333"/>
+<text x="564.952380952381" y="428" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.5</text>
+<line x1="670.984126984127" y1="404" x2="670.984126984127" y2="410" stroke="#333"/>
+<text x="670.984126984127" y="428" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.6</text>
+<line x1="50" y1="350.08834578681115" x2="56" y2="350.08834578681115" stroke="#333"/>
+<text x="46" y="354.08834578681115" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.0</text>
+<line x1="50" y1="290.2650373604334" x2="56" y2="290.2650373604334" stroke="#333"/>
+<text x="46" y="294.2650373604334" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.1</text>
+<line x1="50" y1="230.44172893405562" x2="56" y2="230.44172893405562" stroke="#333"/>
+<text x="46" y="234.44172893405562" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.2</text>
+<line x1="50" y1="170.6184205076779" x2="56" y2="170.6184205076779" stroke="#333"/>
+<text x="46" y="174.6184205076779" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.3</text>
+<line x1="50" y1="110.79511208130015" x2="56" y2="110.79511208130015" stroke="#333"/>
+<text x="46" y="114.79511208130015" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.4</text>
+<line x1="50" y1="50.97180365492244" x2="56" y2="50.97180365492244" stroke="#333"/>
+<text x="46" y="54.97180365492244" text-anchor="end" font-family="Helvetica,Arial,sans-serif" font-size="12" fill="#222">0.5</text>
+<line x1="247.06920634920638" y1="56" x2="247.06920634920638" y2="404" stroke="#111" stroke-width="2.5" stroke-dasharray="6 4"/>
+<circle cx="247.06920634920638" cy="404" r="4" fill="#111"/>
+<polyline fill="none" stroke="#4b6cb7" stroke-width="3" points="56.0,325.53 66.6,332.19 77.21,332.21 87.81,339.72 98.41,346.78 109.02,354.5 119.62,360.47 130.22,350.77 140.83,345.9 151.43,348.53 162.03,343.34 172.63,345.59 183.24,344.94 193.84,333.84 204.44,336.85 215.05,340.53 225.65,340.59 236.25,342.52 246.86,343.76 257.46,345.93 268.06,346.08 278.67,350.46 289.27,348.74 299.87,348.81 310.48,348.8 321.08,343.84 331.68,344.85 342.29,342.42 352.89,345.58 363.49,348.31 374.1,348.86 384.7,352.47 395.3,352.48 405.9,352.73 416.51,353.98 427.11,353.63 437.71,352.66 448.32,351.67 458.92,351.73 469.52,352.64 480.13,353.59 490.73,352.29 501.33,354.1 511.94,356.28 522.54,353.78 533.14,354.71 543.75,357.22 554.35,358.21 564.95,357.5 575.56,358.11 586.16,359.27 596.76,357.7 607.37,362.5 617.97,365.6 628.57,367.73 639.17,370.83 649.78,369.76 660.38,368.26 670.98,365.13 681.59,366.22 692.19,363.1 702.79,361.13 713.4,360.26 724.0,356.89"/>
+<polyline fill="none" stroke="#c43c39" stroke-width="3" points="56.0,303.35 66.6,271.61 77.21,244.41 87.81,219.41 98.41,194.7 109.02,174.21 119.62,158.08 130.22,148.57 140.83,143.08 151.43,127.7 162.03,121.67 172.63,112.73 183.24,101.32 193.84,97.35 204.44,90.01 215.05,89.39 225.65,85.49 236.25,81.9 246.86,80.87 257.46,80.0 268.06,80.46 278.67,82.54 289.27,83.8 299.87,87.6 310.48,91.5 321.08,97.2 331.68,103.07 342.29,108.68 352.89,113.68 363.49,118.68 374.1,124.4 384.7,130.37 395.3,135.52 405.9,141.48 416.51,147.16 427.11,153.11 437.71,159.22 448.32,164.92 458.92,170.69 469.52,176.72 480.13,182.93 490.73,188.82 501.33,194.96 511.94,200.86 522.54,206.25 533.14,212.15 543.75,218.14 554.35,223.84 564.95,228.69 575.56,233.89 586.16,238.72 596.76,244.24 607.37,249.87 617.97,252.95 628.57,258.67 639.17,263.11 649.78,266.76 660.38,270.19 670.98,274.51 681.59,277.57 692.19,280.99 702.79,282.11 713.4,285.63 724.0,286.09"/>
+<text x="540" y="72" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#4b6cb7">homogeneous - CSR</text>
+<text x="540" y="96" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#c43c39">clustered - CSR</text>
+<text x="247.06920634920638" y="42" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="14" font-weight="bold" fill="#111">reference r = 0.2</text>
+<text x="350.0" y="444" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#222">r</text>
+<text x="14" y="230.0" transform="rotate(-90 14,230.0)" font-family="Helvetica,Arial,sans-serif" font-size="15" fill="#222">H_excess(r)</text>
+</svg>

--- a/examples/ripley_peak_calibration.jl
+++ b/examples/ripley_peak_calibration.jl
@@ -1,0 +1,80 @@
+using Printf
+using Random
+using VortexDistributions
+
+function clustered_disk_vortices(
+    rng::AbstractRNG,
+    n::Integer,
+    q::Integer,
+    radius::Real,
+    cluster_width::Real;
+    centers = [(-0.35radius, 0.15radius), (0.30radius, -0.20radius)],
+)
+    vortices = PointVortex[]
+    while length(vortices) < n
+        x0, y0 = rand(rng, centers)
+        x = x0 + cluster_width * randn(rng)
+        y = y0 + cluster_width * randn(rng)
+        hypot(x, y) <= radius && push!(vortices, PointVortex(x, y, q))
+    end
+    return vortices
+end
+
+function summarize(values)
+    sorted = sort(values)
+    n = length(sorted)
+    median = isodd(n) ? sorted[(n+1)÷2] : (sorted[n÷2] + sorted[n÷2+1]) / 2
+    lo = sorted[max(1, round(Int, 0.16n))]
+    hi = sorted[min(n, round(Int, 0.84n))]
+    return median, lo, hi
+end
+
+function calibrate_peak(
+    rng::AbstractRNG;
+    radius = 1.0,
+    n = 40,
+    widths = [0.04, 0.06, 0.08, 0.10, 0.12],
+    realizations = 80,
+    baseline_samples = 200,
+)
+    window = DiskWindow(radius)
+    r = collect(range(0.02radius, 0.65radius; length = 96))
+
+    println(
+        "Ripley-excess peak calibration for two Gaussian same-sign clusters in a unit disk",
+    )
+    println("Each cluster has coordinate width σ; table reports median and 16-84% range.")
+    println()
+    println(
+        "σ       median r_peak   16-84% r_peak       median r_peak/σ   median r_peak/(2σ)",
+    )
+
+    for σ in widths
+        peaks = Float64[]
+        for _ = 1:realizations
+            vortices = clustered_disk_vortices(rng, n, 1, radius, σ)
+            summary = ripley_excess(
+                vortices,
+                r,
+                window;
+                charge = 1,
+                samples = baseline_samples,
+                rng,
+            )
+            push!(peaks, summary.radius)
+        end
+
+        median, lo, hi = summarize(peaks)
+        @printf(
+            "%0.3f   %0.4f          [%0.4f, %0.4f]      %0.3f             %0.3f\n",
+            σ,
+            median,
+            lo,
+            hi,
+            median / σ,
+            median / (2σ),
+        )
+    end
+end
+
+calibrate_peak(MersenneTwister(7))

--- a/src/Analysis2D.jl
+++ b/src/Analysis2D.jl
@@ -2,10 +2,25 @@ module Analysis2D
 
 using Interpolations
 
-using ..Core: Field, PointVortex, pos, Δ
+using ..Core: Field, PointVortex, charge, pos, xpos, ypos, Δ
 
 include("Analysis2D/phase_tools.jl")
+include("Analysis2D/ripley.jl")
 
-export circ_mask, keep_vortices, phase_jumps, phase_jumps!, unwrap, unwrap!, zoom_grid, zoom_interp
+export DiskWindow,
+    RipleyKResult,
+    besag_l,
+    circ_mask,
+    keep_vortices,
+    phase_jumps,
+    phase_jumps!,
+    ripley_csr_baseline,
+    ripley_clustering,
+    ripley_excess,
+    ripley_k,
+    unwrap,
+    unwrap!,
+    zoom_grid,
+    zoom_interp
 
 end

--- a/src/Analysis2D/ripley.jl
+++ b/src/Analysis2D/ripley.jl
@@ -1,0 +1,296 @@
+"""
+    DiskWindow(radius[, center])
+
+Circular physical observation window for 2D point-vortex statistics.
+"""
+struct DiskWindow{T<:Real}
+    radius::T
+    center::Tuple{T,T}
+end
+
+function DiskWindow(radius::T) where {T<:Real}
+    radius > 0 || throw(ArgumentError("disk radius must be positive"))
+    return DiskWindow{T}(radius, (zero(T), zero(T)))
+end
+
+function DiskWindow(radius::Real, center::Tuple{<:Real,<:Real})
+    return DiskWindow(promote(radius, center...)...)
+end
+
+function DiskWindow(radius::T, x0::T, y0::T) where {T<:Real}
+    radius > 0 || throw(ArgumentError("disk radius must be positive"))
+    return DiskWindow{T}(radius, (x0, y0))
+end
+
+"""
+    RipleyKResult
+
+Scale-resolved same-sign Ripley statistics. `K` is Ripley's K function,
+`L = sqrt(K / π)` is Besag's L function, and `H = L - r` is positive
+when same-sign vortices cluster relative to complete spatial randomness.
+"""
+struct RipleyKResult{T<:Real}
+    r::Vector{T}
+    K::Vector{T}
+    L::Vector{T}
+    H::Vector{T}
+    charge::Int
+    window::DiskWindow{T}
+end
+
+function _inside(window::DiskWindow, x::Real, y::Real)
+    (; radius, center) = window
+    x0, y0 = center
+    return hypot(x - x0, y - y0) <= radius
+end
+
+_vortex_charge(vortex::PointVortex) = charge(vortex)
+
+function _circle_fraction_inside_disk(window::DiskWindow, x::Real, y::Real, r::Real)
+    (; radius, center) = window
+    x0, y0 = center
+    ρ = hypot(x - x0, y - y0)
+    r <= radius - ρ && return one(float(r))
+    (ρ == 0 || r == 0) && return zero(float(r))
+    c = (radius^2 - ρ^2 - r^2) / (2ρ * r)
+    c >= 1 && return one(float(c))
+    c <= -1 && return zero(float(c))
+    return 1 - acos(clamp(c, -1, 1)) / π
+end
+
+function _same_charge_positions(
+    vortices::AbstractVector{PointVortex},
+    q::Integer,
+    window::DiskWindow,
+)
+    T = promote_type(Float64, typeof(window.radius))
+    xs = T[]
+    ys = T[]
+    for vortex in vortices
+        x = T(xpos(vortex))
+        y = T(ypos(vortex))
+        if charge(vortex) == q && _inside(window, x, y)
+            push!(xs, x)
+            push!(ys, y)
+        end
+    end
+    return xs, ys
+end
+
+_rand(rng::Nothing) = rand()
+_rand(rng) = rand(rng)
+_randn(rng::Nothing) = randn()
+_randn(rng) = randn(rng)
+
+function _random_disk_vortices(rng, n::Integer, q::Integer, window::DiskWindow)
+    (; radius, center) = window
+    x0, y0 = center
+    vortices = PointVortex[]
+    sizehint!(vortices, n)
+    for _ = 1:n
+        ρ = radius * sqrt(_rand(rng))
+        θ = 2π * _rand(rng)
+        x = x0 + ρ * cos(θ)
+        y = y0 + ρ * sin(θ)
+        push!(vortices, PointVortex(x, y, q))
+    end
+    return vortices
+end
+
+"""
+    ripley_k(vortices, r, window; charge = 1)
+
+Compute the same-sign Ripley K function for `PointVortex` positions inside
+`window`. Distances are physical Euclidean distances, and disk windows use an
+isotropic boundary correction.
+"""
+function ripley_k(
+    vortices::AbstractVector{PointVortex},
+    r::AbstractVector{<:Real},
+    window::DiskWindow;
+    charge::Integer = 1,
+)
+    q = Int(charge)
+    all(>=(0), r) || throw(ArgumentError("Ripley radii must be non-negative"))
+    xs, ys = _same_charge_positions(vortices, q, window)
+    T = promote_type(eltype(xs), eltype(r), typeof(window.radius))
+    rs = T.(r)
+    K = zeros(T, length(rs))
+    n = length(xs)
+
+    if n < 2
+        L = zeros(T, length(rs))
+        H = L .- rs
+        return RipleyKResult(
+            rs,
+            K,
+            L,
+            H,
+            q,
+            DiskWindow{T}(T(window.radius), T.(window.center)),
+        )
+    end
+
+    area = T(π) * T(window.radius)^2
+    for i in eachindex(xs)
+        xi = xs[i]
+        yi = ys[i]
+        for j in eachindex(xs)
+            i == j && continue
+            d = hypot(xi - xs[j], yi - ys[j])
+            fraction = _circle_fraction_inside_disk(window, xi, yi, d)
+            fraction <= 0 && continue
+            weight = inv(T(fraction))
+            for k in eachindex(rs)
+                d <= rs[k] && (K[k] += weight)
+            end
+        end
+    end
+
+    scale = area / (n * (n - 1))
+    K .*= scale
+    L = sqrt.(K ./ T(π))
+    H = L .- rs
+    return RipleyKResult(rs, K, L, H, q, DiskWindow{T}(T(window.radius), T.(window.center)))
+end
+
+function ripley_k(
+    vortices::AbstractVector{PointVortex},
+    r::Real,
+    window::DiskWindow;
+    charge::Integer = 1,
+)
+    return only(ripley_k(vortices, [r], window; charge).K)
+end
+
+"""
+    besag_l(vortices, r, window; charge = 1)
+
+Compute Besag's `L(r) = sqrt(K(r) / π)` for the same-sign vortex subset.
+"""
+function besag_l(
+    vortices::AbstractVector{PointVortex},
+    r::AbstractVector{<:Real},
+    window::DiskWindow;
+    charge::Integer = 1,
+)
+    return ripley_k(vortices, r, window; charge).L
+end
+
+function besag_l(
+    vortices::AbstractVector{PointVortex},
+    r::Real,
+    window::DiskWindow;
+    charge::Integer = 1,
+)
+    return only(besag_l(vortices, [r], window; charge))
+end
+
+"""
+    ripley_csr_baseline(n, r, window; charge = 1, samples = 200, rng = nothing)
+
+Estimate the homogeneous complete-spatial-randomness baseline in the same disk
+window from `samples` random point sets with `n` same-sign vortices.
+"""
+function ripley_csr_baseline(
+    n::Integer,
+    r::AbstractVector{<:Real},
+    window::DiskWindow;
+    charge::Integer = 1,
+    samples::Integer = 200,
+    rng = nothing,
+)
+    samples > 0 || throw(ArgumentError("number of CSR samples must be positive"))
+    rs = float.(r)
+    mean_K = zeros(eltype(rs), length(rs))
+    mean_L = similar(mean_K)
+    mean_H = similar(mean_K)
+
+    for _ = 1:samples
+        vortices = _random_disk_vortices(rng, n, charge, window)
+        result = ripley_k(vortices, r, window; charge)
+        mean_K .+= result.K
+        mean_L .+= result.L
+        mean_H .+= result.H
+    end
+
+    mean_K ./= samples
+    mean_L ./= samples
+    mean_H ./= samples
+    return (;
+        r = rs,
+        K = mean_K,
+        L = mean_L,
+        H = mean_H,
+        charge = Int(charge),
+        window,
+        samples,
+    )
+end
+
+function _positive_integral(r::AbstractVector, y::AbstractVector)
+    integral = zero(eltype(y))
+    for i = 2:length(r)
+        Δr = r[i] - r[i-1]
+        h = max((y[i] + y[i-1]) / 2, zero(integral))
+        integral += h * Δr
+    end
+    return integral
+end
+
+"""
+    ripley_excess(vortices, r, window; charge = 1, samples = 200, rng = nothing)
+
+Compute `H_excess(r) = H_observed(r) - mean(H_CSR(r))` using homogeneous
+random point sets in the same disk window. The returned `maximum`, `radius`,
+and `integral` are evaluated on `H_excess`.
+"""
+function ripley_excess(
+    vortices::AbstractVector{PointVortex},
+    r::AbstractVector{<:Real},
+    window::DiskWindow;
+    charge::Integer = 1,
+    samples::Integer = 200,
+    rng = nothing,
+)
+    q = Int(charge)
+    result = ripley_k(vortices, r, window; charge = q)
+    n = count(
+        vortex ->
+            _vortex_charge(vortex) == q && _inside(window, xpos(vortex), ypos(vortex)),
+        vortices,
+    )
+    baseline = ripley_csr_baseline(n, r, window; charge = q, samples, rng)
+    H = result.H .- baseline.H
+    isempty(H) &&
+        return (; result, baseline, H, maximum = NaN, radius = NaN, integral = NaN)
+    index = argmax(H)
+    return (;
+        result,
+        baseline,
+        H,
+        maximum = H[index],
+        radius = result.r[index],
+        integral = _positive_integral(result.r, H),
+    )
+end
+
+"""
+    ripley_clustering(vortices, r, window; charge = 1)
+
+Return the full Ripley result plus simple same-sign clustering summaries:
+the maximum `H = L - r`, the radius where it occurs, and the positive
+trapezoidal integral of `H`.
+"""
+function ripley_clustering(
+    vortices::AbstractVector{PointVortex},
+    r::AbstractVector{<:Real},
+    window::DiskWindow;
+    charge::Integer = 1,
+)
+    result = ripley_k(vortices, r, window; charge)
+    isempty(result.H) && return (; result, maximum = NaN, radius = NaN, integral = NaN)
+    index = argmax(result.H)
+    integral = _positive_integral(result.r, result.H)
+    return (; result, maximum = result.H[index], radius = result.r[index], integral)
+end

--- a/src/Analysis2D/ripley.jl
+++ b/src/Analysis2D/ripley.jl
@@ -50,9 +50,13 @@ function _circle_fraction_inside_disk(window::DiskWindow, x::Real, y::Real, r::R
     (; radius, center) = window
     x0, y0 = center
     ρ = hypot(x - x0, y - y0)
+    (!isfinite(ρ) || !isfinite(r)) && return zero(float(r))
     r <= radius - ρ && return one(float(r))
     (ρ == 0 || r == 0) && return zero(float(r))
-    c = (radius^2 - ρ^2 - r^2) / (2ρ * r)
+    denominator = 2ρ * r
+    (denominator == 0 || !isfinite(denominator)) && return zero(float(r))
+    c = (radius^2 - ρ^2 - r^2) / denominator
+    !isfinite(c) && return zero(float(c))
     c >= 1 && return one(float(c))
     c <= -1 && return zero(float(c))
     return 1 - acos(clamp(c, -1, 1)) / π
@@ -139,8 +143,10 @@ function ripley_k(
             i == j && continue
             d = hypot(xi - xs[j], yi - ys[j])
             fraction = _circle_fraction_inside_disk(window, xi, yi, d)
-            fraction <= 0 && continue
-            weight = inv(T(fraction))
+            fraction = T(fraction)
+            (!isfinite(fraction) || fraction <= eps(T)) && continue
+            weight = inv(fraction)
+            !isfinite(weight) && continue
             for k in eachindex(rs)
                 d <= rs[k] && (K[k] += weight)
             end
@@ -233,6 +239,7 @@ function _positive_integral(r::AbstractVector, y::AbstractVector)
     for i = 2:length(r)
         Δr = r[i] - r[i-1]
         h = max((y[i] + y[i-1]) / 2, zero(integral))
+        isfinite(h) || continue
         integral += h * Δr
     end
     return integral
@@ -264,7 +271,10 @@ function ripley_excess(
     H = result.H .- baseline.H
     isempty(H) &&
         return (; result, baseline, H, maximum = NaN, radius = NaN, integral = NaN)
-    index = argmax(H)
+    finite_indices = findall(isfinite, H)
+    isempty(finite_indices) &&
+        return (; result, baseline, H, maximum = NaN, radius = NaN, integral = NaN)
+    index = finite_indices[argmax(H[finite_indices])]
     return (;
         result,
         baseline,

--- a/src/VortexDistributions.jl
+++ b/src/VortexDistributions.jl
@@ -7,7 +7,8 @@ include("Detection2D.jl")
 include("Detection3D.jl")
 include("RecursiveClusterAlgorithm.jl")
 
-using .Core: Ansatz,
+using .Core:
+    Ansatz,
     ChannelVortex,
     Cluster,
     CoreShape,
@@ -25,8 +26,24 @@ using .Core: Ansatz,
     xpos,
     ypos,
     vortex_array
-using .Analysis2D: circ_mask, keep_vortices, phase_jumps, phase_jumps!, unwrap, unwrap!, zoom_grid, zoom_interp
-using .Creation2D: gpecore_exact,
+using .Analysis2D:
+    DiskWindow,
+    RipleyKResult,
+    besag_l,
+    circ_mask,
+    keep_vortices,
+    phase_jumps,
+    phase_jumps!,
+    ripley_csr_baseline,
+    ripley_clustering,
+    ripley_excess,
+    ripley_k,
+    unwrap,
+    unwrap!,
+    zoom_grid,
+    zoom_interp
+using .Creation2D:
+    gpecore_exact,
     periodic_dipole!,
     rand_charge,
     rand_scalarvortex,
@@ -36,7 +53,8 @@ using .Creation2D: gpecore_exact,
     thetad,
     dipole_phase,
     vortex!
-using .Detection2D: findvortices, findvortices_grid, findvortices_jumps, found_near, remove_vortices_edge
+using .Detection2D:
+    findvortices, findvortices_grid, findvortices_jumps, found_near, remove_vortices_edge
 using .Detection3D: detect_vortices_3d, full_algorithm
 using .RecursiveClusterAlgorithm: RCAResult, recursive_cluster_algorithm
 
@@ -45,6 +63,8 @@ export PointVortex, ScalarVortex
 export findvortices, findvortices_grid, findvortices_jumps
 export phase_jumps, phase_jumps!, unwrap, unwrap!, zoom_interp, zoom_grid
 export remove_vortices_edge, keep_vortices, circ_mask
+export DiskWindow,
+    RipleyKResult, besag_l, ripley_csr_baseline, ripley_clustering, ripley_excess, ripley_k
 export vortex_array
 export scalar_ansatz, vortex!, dipole_phase, periodic_dipole!
 export rand_charge, rand_pointvortex, rand_scalarvortex, rand_vortex, rand_vortexfield

--- a/test/ripley_test.jl
+++ b/test/ripley_test.jl
@@ -106,14 +106,22 @@ end
 @testset "CSR-normalized Ripley excess" begin
     window = DiskWindow(1.0)
     r = collect(range(0.05, 0.5; length = 8))
-    vortices =
-        [PointVortex(0.0, 0.0, 1), PointVortex(0.05, 0.0, 1), PointVortex(0.1, 0.0, 1)]
-    baseline = ripley_csr_baseline(3, r, window; samples = 8, rng = TestRNG(11))
-    excess = ripley_excess(vortices, r, window; samples = 8, rng = TestRNG(11))
+    vortices = [
+        PointVortex(0.0, 0.0, 1),
+        PointVortex(0.05, 0.0, 1),
+        PointVortex(0.1, 0.0, 1),
+        PointVortex(0.0, 0.1, 1),
+        PointVortex(-0.08, 0.02, 1),
+    ]
+    baseline =
+        ripley_csr_baseline(length(vortices), r, window; samples = 16, rng = TestRNG(11))
+    excess = ripley_excess(vortices, r, window; samples = 16, rng = TestRNG(11))
 
     @test length(baseline.H) == length(r)
-    @test excess.H == excess.result.H .- excess.baseline.H
-    @test excess.maximum == maximum(excess.H)
+    @test all(isfinite, baseline.H)
+    @test all(isfinite, excess.H)
+    @test excess.H ≈ excess.result.H .- excess.baseline.H
+    @test excess.maximum ≈ maximum(excess.H)
     @test excess.integral >= 0
 end
 

--- a/test/ripley_test.jl
+++ b/test/ripley_test.jl
@@ -1,0 +1,139 @@
+using Test
+using VortexDistributions
+
+mutable struct TestRNG
+    state::UInt64
+end
+
+function Base.rand(rng::TestRNG)
+    rng.state = 6364136223846793005 * rng.state + 1442695040888963407
+    return Float64(rng.state >> 11) * inv(Float64(1 << 53))
+end
+
+function Base.rand(rng::TestRNG, values::AbstractVector)
+    return values[clamp(1 + floor(Int, rand(rng) * length(values)), 1, length(values))]
+end
+
+function Base.randn(rng::TestRNG)
+    u1 = max(rand(rng), eps())
+    u2 = rand(rng)
+    return sqrt(-2log(u1)) * cos(2π * u2)
+end
+
+function test_random_disk_point(rng::TestRNG, radius::Real)
+    ρ = radius * sqrt(rand(rng))
+    θ = 2π * rand(rng)
+    return ρ * cos(θ), ρ * sin(θ)
+end
+
+function test_random_disk_vortices(rng::TestRNG, n::Integer, q::Integer, radius::Real)
+    return [PointVortex(test_random_disk_point(rng, radius)..., q) for _ = 1:n]
+end
+
+function test_clustered_disk_vortices(
+    rng::TestRNG,
+    n::Integer,
+    q::Integer,
+    radius::Real,
+    σ::Real,
+)
+    centers = [(-0.35radius, 0.15radius), (0.30radius, -0.20radius)]
+    vortices = PointVortex[]
+    while length(vortices) < n
+        x0, y0 = rand(rng, centers)
+        x = x0 + σ * randn(rng)
+        y = y0 + σ * randn(rng)
+        hypot(x, y) <= radius && push!(vortices, PointVortex(x, y, q))
+    end
+    return vortices
+end
+
+@testset "Disk window construction" begin
+    window = DiskWindow(10.0)
+    @test window.radius == 10.0
+    @test window.center == (0.0, 0.0)
+    @test DiskWindow(10, (1, 2)).center == (1, 2)
+    @test_throws ArgumentError DiskWindow(0.0)
+end
+
+@testset "Same-sign Ripley K" begin
+    window = DiskWindow(10.0)
+    vortices = [
+        PointVortex(0.0, 0.0, 1),
+        PointVortex(1.0, 0.0, 1),
+        PointVortex(0.5, 0.0, -1),
+        PointVortex(20.0, 0.0, 1),
+    ]
+
+    r = [0.5, 1.0, 2.0]
+    result = ripley_k(vortices, r, window; charge = 1)
+
+    @test result isa RipleyKResult
+    @test result.charge == 1
+    @test result.r == r
+    @test result.K[1] == 0
+    @test result.K[2] ≈ 100π
+    @test result.K[3] ≈ 100π
+    @test result.L[2] ≈ 10.0
+    @test result.H[2] ≈ 9.0
+    @test ripley_k(vortices, 1.0, window; charge = 1) ≈ 100π
+    @test besag_l(vortices, 1.0, window; charge = 1) ≈ 10.0
+
+    negative_result = ripley_k(vortices, r, window; charge = -1)
+    @test all(iszero, negative_result.K)
+    @test negative_result.H == -r
+end
+
+@testset "Disk edge correction" begin
+    window = DiskWindow(1.0)
+    vortices = [PointVortex(0.95, 0.0, 1), PointVortex(0.85, 0.0, 1)]
+
+    result = ripley_k(vortices, [0.1], window; charge = 1)
+    @test only(result.K) > π
+end
+
+@testset "Ripley clustering summary" begin
+    window = DiskWindow(10.0)
+    vortices = [PointVortex(0.0, 0.0, 1), PointVortex(1.0, 0.0, 1)]
+    summary = ripley_clustering(vortices, [0.5, 1.0, 2.0], window; charge = 1)
+
+    @test summary.maximum ≈ 9.0
+    @test summary.radius ≈ 1.0
+    @test summary.integral > 0
+    @test_throws ArgumentError ripley_k(vortices, [-1.0], window)
+end
+
+@testset "CSR-normalized Ripley excess" begin
+    window = DiskWindow(1.0)
+    r = collect(range(0.05, 0.5; length = 8))
+    vortices =
+        [PointVortex(0.0, 0.0, 1), PointVortex(0.05, 0.0, 1), PointVortex(0.1, 0.0, 1)]
+    baseline = ripley_csr_baseline(3, r, window; samples = 8, rng = TestRNG(11))
+    excess = ripley_excess(vortices, r, window; samples = 8, rng = TestRNG(11))
+
+    @test length(baseline.H) == length(r)
+    @test excess.H == excess.result.H .- excess.baseline.H
+    @test excess.maximum == maximum(excess.H)
+    @test excess.integral >= 0
+end
+
+@testset "Synthetic cluster peak regression" begin
+    window = DiskWindow(1.0)
+    σ = 0.07
+    r = collect(range(0.02, 0.65; length = 64))
+    data_rng = TestRNG(42)
+    baseline_seed = 1
+
+    homogeneous = test_random_disk_vortices(data_rng, 40, 1, window.radius)
+    clustered = test_clustered_disk_vortices(data_rng, 40, 1, window.radius, σ)
+
+    homogeneous_summary =
+        ripley_excess(homogeneous, r, window; samples = 150, rng = TestRNG(baseline_seed))
+    clustered_summary =
+        ripley_excess(clustered, r, window; samples = 150, rng = TestRNG(baseline_seed))
+
+    @test homogeneous_summary.maximum < 0.08
+    @test clustered_summary.maximum > 0.35
+    @test clustered_summary.integral > 20homogeneous_summary.integral
+    @test clustered_summary.radius ≈ 2.86σ atol = 0.025
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,10 @@ end
     include("keep_vortices_test.jl")
 end
 
+@testset "Ripley Clustering" begin
+    include("ripley_test.jl")
+end
+
 @testset "API Regression" begin
     include("api_regression_test.jl")
 end


### PR DESCRIPTION
## Summary

Adds same-sign Ripley clustering analysis for 2D point-vortex distributions, including:

- disk-window Ripley K / Besag L / `H = L - r` calculations over physical Euclidean distances
- CSR-subtracted `ripley_excess` summaries for homogeneous-baseline-normalized clustering
- a deterministic regression test that separates homogeneous synthetic vortices from a two-cluster same-sign distribution
- runnable example scripts for generating the diagnostic SVG and calibrating the Ripley peak against the known Gaussian cluster width
- a README section linking the runnable example and generated figure

## Explanation

The new `DiskWindow` and `RipleyKResult` types live in `Analysis2D`, with exported helpers `ripley_k`, `besag_l`, `ripley_csr_baseline`, `ripley_excess`, and `ripley_clustering`.

The implementation uses physical pair distances inside a disk, not periodic distances. Disk boundary effects are handled with an isotropic edge correction based on the visible circumference fraction for each directed pair contribution. For the normalized clustering diagnostic, `ripley_excess` estimates a homogeneous complete-spatial-randomness baseline in the same disk and subtracts the mean `H_CSR(r)` from the observed `H(r)`.

The synthetic example compares homogeneous same-sign vortices against a two-Gaussian-cluster distribution, writes `examples/ripley_disk_synthetic.svg`, and labels the calibrated reference peak scale on the figure. A second example performs a Monte Carlo calibration of the Ripley peak radius against the input Gaussian cluster width.

No new package dependencies are added.

## Tests

- `julia --project=. -e 'using JuliaFormatter; format(["src/Analysis2D.jl", "src/Analysis2D/ripley.jl", "src/VortexDistributions.jl", "test/ripley_test.jl", "test/runtests.jl", "examples/ripley_disk_synthetic.jl", "examples/ripley_peak_calibration.jl"])'`
  - completed successfully and formatted the changed Julia files
- `julia --project=. examples/ripley_disk_synthetic.jl`
  - passed; generated `examples/ripley_disk_synthetic.svg`
  - homogeneous `max(H_excess) = 0.0411`, clustered `max(H_excess) = 0.4515`
- `julia --project=. examples/ripley_peak_calibration.jl`
  - passed; reported median calibrated `r_peak / σ` decreasing from `3.318` at `σ = 0.040` to `2.377` at `σ = 0.120`
- `julia --project=. -e 'using Pkg; Pkg.test()'`
  - passed the full package test suite, including the new `Ripley Clustering` testset with 29 passing assertions

## Notes

This adds new exported analysis API, but does not change existing detection, creation, or recursive-cluster behavior.
